### PR TITLE
improve: check providerMetadata first for think setting

### DIFF
--- a/src/ollama-chat-language-model.ts
+++ b/src/ollama-chat-language-model.ts
@@ -169,7 +169,6 @@ export class OllamaChatLanguageModel implements LanguageModelV1 {
       max_tokens: maxTokens,
       temperature,
       top_p: topP,
-      think: this.settings.think,
       frequency_penalty: frequencyPenalty,
       presence_penalty: presencePenalty,
       response_format:
@@ -198,6 +197,8 @@ export class OllamaChatLanguageModel implements LanguageModelV1 {
       reasoning_effort:
         providerMetadata?.ollama?.reasoningEffort ??
         this.settings.reasoningEffort,
+      think: providerMetadata?.ollama?.think ?? this.settings.think,
+
 
       // messages:
       messages: convertToOllamaChatMessages({

--- a/src/ollama-completion-language-model.ts
+++ b/src/ollama-completion-language-model.ts
@@ -72,6 +72,7 @@ export class OllamaCompletionLanguageModel implements LanguageModelV1 {
     stopSequences: userStopSequences,
     responseFormat,
     seed,
+    providerMetadata
   }: Parameters<LanguageModelV1['doGenerate']>[0]) {
     const type = mode.type;
 
@@ -119,7 +120,6 @@ export class OllamaCompletionLanguageModel implements LanguageModelV1 {
       max_tokens: maxTokens,
       temperature,
       top_p: topP,
-      think: this.settings.think,
       frequency_penalty: frequencyPenalty,
       presence_penalty: presencePenalty,
       seed,
@@ -129,6 +129,10 @@ export class OllamaCompletionLanguageModel implements LanguageModelV1 {
 
       // stop sequences:
       stop: stop.length > 0 ? stop : undefined,
+
+      // ollama specific settings:
+      think: providerMetadata?.ollama?.think ?? this.settings.think,
+
     };
 
     switch (type) {


### PR DESCRIPTION
Hi, thank you for maintaining a new version of Ollama provider for ai-sdk (we need to ask Vercel guys to update their docs to point to this repo - the other one is seriously outdated).

Upon thinking about the thinking option :P, I think this parameter is specific to Ollama and would be most suitable to be set under providerMetadata. Since you already released it to be under model settings, can we at least check it in the providerMetadata first and then fall back to the one under settings to maintain backwards compatibility?

Thank you for your consideration.