### PR TITLE
fix: support reasoning part type of assistant content

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@vercel/ai-tsconfig": "./tsconfig",
     "tsup": "^8",
     "typescript": "5.6.3",
+    "vitest": "^3.2.4",
     "zod": "3.23.8"
   },
   "peerDependencies": {

--- a/src/convert-to-ollama-chat-messages.test.ts
+++ b/src/convert-to-ollama-chat-messages.test.ts
@@ -242,6 +242,30 @@ describe('user messages', () => {
   });
 });
 
+describe('assistant messages', () => {
+  it('should handle reasoning parts in assistant content', () => {
+    const result = convertToOllamaChatMessages({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'Let me think about this.' },
+            { type: 'reasoning', text: 'This is my reasoning process.' },
+            { type: 'text', text: ' The answer is 42.' },
+          ],
+        },
+      ],
+    });
+
+    expect(result).toEqual([
+      {
+        role: 'assistant',
+        content: 'Let me think about this.This is my reasoning process. The answer is 42.',
+      },
+    ]);
+  });
+});
+
 describe('tool calls', () => {
   it('should stringify arguments to tool calls', () => {
     const result = convertToOllamaChatMessages({

--- a/src/convert-to-ollama-chat-messages.test.ts
+++ b/src/convert-to-ollama-chat-messages.test.ts
@@ -260,7 +260,8 @@ describe('assistant messages', () => {
     expect(result).toEqual([
       {
         role: 'assistant',
-        content: 'Let me think about this.This is my reasoning process. The answer is 42.',
+        content: 'Let me think about this. The answer is 42.',
+        thinking: 'This is my reasoning process.',
       },
     ]);
   });

--- a/src/convert-to-ollama-chat-messages.ts
+++ b/src/convert-to-ollama-chat-messages.ts
@@ -132,6 +132,10 @@ export function convertToOllamaChatMessages({
               });
               break;
             }
+            case 'reasoning': {
+              text += part.text;
+              break;
+            } 
             default: {
               const _exhaustiveCheck: never = part;
               throw new Error(`Unsupported part: ${_exhaustiveCheck}`);

--- a/src/convert-to-ollama-chat-messages.ts
+++ b/src/convert-to-ollama-chat-messages.ts
@@ -109,6 +109,7 @@ export function convertToOllamaChatMessages({
 
       case 'assistant': {
         let text = '';
+        let thinking = '';
         const toolCalls: Array<{
           id: string;
           type: 'function';
@@ -133,7 +134,7 @@ export function convertToOllamaChatMessages({
               break;
             }
             case 'reasoning': {
-              text += part.text;
+              thinking += part.text;
               break;
             } 
             default: {
@@ -154,6 +155,7 @@ export function convertToOllamaChatMessages({
           messages.push({
             role: 'assistant',
             content: text,
+            ...(thinking && { thinking }),
             function_call:
               toolCalls.length > 0 ? toolCalls[0].function : undefined,
           });
@@ -161,6 +163,7 @@ export function convertToOllamaChatMessages({
           messages.push({
             role: 'assistant',
             content: text,
+            ...(thinking && { thinking }),
             tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
           });
         }


### PR DESCRIPTION
To recreate the error, I initialize my models with `extractReasoningMiddleware` so reasoning parts get parsed by the sdk automatically and that's how I ran into this issue.

```
import { createOllama } from 'ollama-ai-provider-v2';
import { customProvider, extractReasoningMiddleware, wrapLanguageModel } from 'ai';

// Create Ollama provider with custom baseURL
const ollama = createOllama({
	baseURL: process.env.OLLAMA_BASE_URL || 'http://localhost:11434'
});

export const myProvider = customProvider({
	languageModels: {
		'chat-model': wrapLanguageModel({
			model: ollama('deepseek-r1:1.5b'),
			middleware: extractReasoningMiddleware({ tagName: 'think' })
		}),
		'chat-model-reasoning': wrapLanguageModel({
			model: ollama('deepseek-r1:7b'),
			middleware: extractReasoningMiddleware({ tagName: 'think' })
		}),
		'title-model': wrapLanguageModel({
			model: ollama('deepseek-r1:1.5b'),
			middleware: extractReasoningMiddleware({ tagName: 'think' })
		}),
		'artifact-model': wrapLanguageModel({
			model: ollama('deepseek-r1:7b'),
			middleware: extractReasoningMiddleware({ tagName: 'think' })
		})
	}
});

```