### PR TITLE
Remove console log statements for tool availability

### DIFF
--- a/src/responses/ollama-responses-prepare-tools.ts
+++ b/src/responses/ollama-responses-prepare-tools.ts
@@ -27,12 +27,10 @@ export function prepareResponsesTools({
   const toolWarnings: LanguageModelV2CallWarning[] = [];
 
   if (tools == null) {
-    console.log("NO TOOLS AVAILABLE");
     return { tools: undefined, toolChoice: undefined, toolWarnings };
   }
 
   const ollamaTools: Array<OllamaResponsesTool> = [];
-  console.log("Available tools:", tools);
 
   for (const tool of tools) {
     switch (tool.type) {


### PR DESCRIPTION
Fixes https://github.com/nordwestt/ollama-ai-provider-v2/issues/13

These logs were likely left for debugging, but it probably makes sense to remove them?

<img width="1354" height="158" alt="image" src="https://github.com/user-attachments/assets/9edfee9e-d0e1-4238-919e-30914bddbd03" />
