### PR TITLE
Use caret range for `@ai-sdk` dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     }
   },
   "dependencies": {
-    "@ai-sdk/provider": "2.0.0",
-    "@ai-sdk/provider-utils": "3.0.1"
+    "@ai-sdk/provider": "^2.0.0",
+    "@ai-sdk/provider-utils": "^3.0.7"
   },
   "devDependencies": {
     "@edge-runtime/vm": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@ai-sdk/provider':
-        specifier: 2.0.0
+        specifier: ^2.0.0
         version: 2.0.0
       '@ai-sdk/provider-utils':
-        specifier: 3.0.1
-        version: 3.0.1(zod@4.0.16)
+        specifier: ^3.0.7
+        version: 3.0.7(zod@4.0.16)
     devDependencies:
       '@edge-runtime/vm':
         specifier: ^5.0.0
@@ -45,8 +45,8 @@ importers:
 
 packages:
 
-  '@ai-sdk/provider-utils@3.0.1':
-    resolution: {integrity: sha512-/iP1sKc6UdJgGH98OCly7sWJKv+J9G47PnTjIj40IJMUQKwDrUMyf7zOOfRtPwSuNifYhSoJQ4s1WltI65gJ/g==}
+  '@ai-sdk/provider-utils@3.0.7':
+    resolution: {integrity: sha512-o3BS5/t8KnBL3ubP8k3w77AByOypLm+pkIL/DCw0qKkhDbvhCy+L3hRTGPikpdb8WHcylAeKsjgwOxhj4cqTUA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4
@@ -629,9 +629,9 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
-  eventsource-parser@3.0.3:
-    resolution: {integrity: sha512-nVpZkTMM9rF6AQ9gPJpFsNAMt48wIzB5TQgiTLdHiuO8XEDhUgZEhqKlZWXbIzo9VmJ/HvysHqEaVeD5v9TPvA==}
-    engines: {node: '>=20.0.0'}
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
 
   expect-type@1.2.1:
     resolution: {integrity: sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==}
@@ -1164,23 +1164,17 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zod-to-json-schema@3.24.6:
-    resolution: {integrity: sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==}
-    peerDependencies:
-      zod: ^3.24.1
-
   zod@4.0.16:
     resolution: {integrity: sha512-Djo/cM339grjI7/HmN+ixYO2FzEMcWr/On50UlQ/RjrWK1I/hPpWhpC76heCptnRFpH0LMwrEbUY50HDc0V8wg==}
 
 snapshots:
 
-  '@ai-sdk/provider-utils@3.0.1(zod@4.0.16)':
+  '@ai-sdk/provider-utils@3.0.7(zod@4.0.16)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@standard-schema/spec': 1.0.0
-      eventsource-parser: 3.0.3
+      eventsource-parser: 3.0.6
       zod: 4.0.16
-      zod-to-json-schema: 3.24.6(zod@4.0.16)
 
   '@ai-sdk/provider@2.0.0':
     dependencies:
@@ -1676,7 +1670,7 @@ snapshots:
 
   esutils@2.0.3: {}
 
-  eventsource-parser@3.0.3: {}
+  eventsource-parser@3.0.6: {}
 
   expect-type@1.2.1: {}
 
@@ -2182,9 +2176,5 @@ snapshots:
       strip-ansi: 7.1.0
 
   yocto-queue@0.1.0: {}
-
-  zod-to-json-schema@3.24.6(zod@4.0.16):
-    dependencies:
-      zod: 4.0.16
 
   zod@4.0.16: {}


### PR DESCRIPTION
Right now, `@ai-sdk` dependencies are pinned to fixed versions:  

https://github.com/nordwestt/ollama-ai-provider-v2/blob/e0eaff6139987822c2863fa15128fed4bf2afeb8/package.json#L40-L41  

This causes issues when installing other providers that rely on different versions of the same packages.  
For example, the latest release of `@ai-sdk/provider-utils` is `3.0.7`, but since this provider depends on `3.0.1`, installing it alongside an official provider like `@ai-sdk/openai` ends up pulling in two separate versions.  

While this can be worked around with [`overrides`](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#overrides), a better long-term solution is to use a caret version range (`^`).  
That way, `npm` will resolve compatible versions automatically, avoiding duplicate dependencies and workarounds.  

---

### Suggestion

To keep dependencies up to date, I recommend adding an automated dependency checker such as Dependabot or Renovate.  
If you’d like, I can open a PR to configure Dependabot so it creates weekly or monthly PRs whenever new versions of `@ai-sdk` packages are released. This ensures tests run against updates early, making it easier to catch potential issues.
