### PR TITLE
fix(types): update import of type for chat settings in OllamaProvider

### DIFF
--- a/src/ollama-provider.ts
+++ b/src/ollama-provider.ts
@@ -8,7 +8,7 @@ import {
   FetchFunction,
   withoutTrailingSlash,
 } from '@ai-sdk/provider-utils';
-import { OllamaChatModelId, ollamaProviderOptions } from './ollama-chat-settings';
+import { OllamaChatModelId, OllamaProviderOptions, ollamaProviderOptions } from './ollama-chat-settings';
 import { OllamaCompletionLanguageModel } from './completion/ollama-completion-language-model';
 import {
   OllamaCompletionModelId,
@@ -34,7 +34,7 @@ Creates an Ollama chat model for text generation.
    */
   chat(
     modelId: OllamaChatModelId,
-    settings?: typeof ollamaProviderOptions,
+    settings?: OllamaProviderOptions,
   ): LanguageModelV2;
 
   /**


### PR DESCRIPTION
Noticed the type was using `typeof` the zod schema, not the inferred type already exported. 