### PR TITLE
Fix dimensions not being passed in embeddings & support provider options

### DIFF
--- a/src/completion/ollama-completion-language-model.ts
+++ b/src/completion/ollama-completion-language-model.ts
@@ -40,6 +40,8 @@ type OllamaCompletionConfig = {
   fetch?: typeof fetch;
 };
 
+export type OllamaCompletionProviderOptions = z.infer<typeof ollamaCompletionProviderOptions>;
+
 export class OllamaCompletionLanguageModel implements LanguageModelV2 {
   readonly specificationVersion = "v2";
 

--- a/src/embedding/ollama-embedding-model.test.ts
+++ b/src/embedding/ollama-embedding-model.test.ts
@@ -97,6 +97,30 @@ describe('doEmbed', () => {
     expect(await server.calls[0].requestBodyJson).toStrictEqual({
       model: 'text-embedding-3-large',
       input: testValues,
+      dimensions: 64,
+    });
+  });
+
+  it('should pass the provider options', async () => {
+    prepareJsonResponse();
+
+    await provider.embedding('text-embedding-3-large').doEmbed({
+      values: testValues,
+      providerOptions: {
+        ollama: {
+          dimensions: 64,
+          truncate: true,
+          keepAlive: '10s',
+        },
+      }
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      model: 'text-embedding-3-large',
+      input: testValues,
+      dimensions: 64,
+      truncate: true,
+      keep_alive: '10s',
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,4 @@
 export { createOllama, ollama } from './ollama-provider';
 export type { OllamaProvider, OllamaProviderSettings } from './ollama-provider';
+export type { OllamaEmbeddingProviderOptions } from './embedding/ollama-embedding-model';
+export type { OllamaCompletionProviderOptions } from './completion/ollama-completion-language-model';


### PR DESCRIPTION
### Fix dimensions not being passed in embeddings & support provider options

This PR fixes an issue of the dimensions setting not being passed to embed requests. Previously the following did not pass the dimensions parameter correctly
```typescript
const model = ollama.embedding('qwen3-embedding:0.6b', { dimensions: 64 })
const result = embed({
    model,
    value
})
```

Additionally I exposed the embedding and completion provider options type and added support for provider options in the request so that we can customize the request according to the Ollama API docs. 

This lets us do things like

```typescript
import { OllamaEmbeddingProviderOptions } from 'ollama-ai-provider-v2' // this type was previously not exposed

const result = embed({
    model,
    value,
    providerOptions: { // these provider options were previously not passed along to the request
      ollama: {
        dimensions: 64
      } satisfies OllamaEmbeddingProviderOptions
    }
})
```
## Key Changes
- Pass dimensions from embedding model settings to request
- Pass provider options to request
- Expose provider options types
- Fix test which was supposed to detect dimensions setting in the request body
- Add a test to make sure provider options are sent with the request

**Note:** The "options" parameter from "advanced parameters" from the [ollama api docs](https://github.com/ollama/ollama/blob/main/docs/api.md#parameters-7) is omitted in this PR. Might be worth adding in the future to have full control over the models in the future