### PR TITLE
fix: remove stale internal export

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
-    "internal/dist/**/*",
     "CHANGELOG.md"
   ],
   "scripts": {
@@ -28,12 +27,6 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
-    },
-    "./internal": {
-      "types": "./internal/dist/index.d.ts",
-      "import": "./internal/dist/index.mjs",
-      "module": "./internal/dist/index.mjs",
-      "require": "./internal/dist/index.js"
     }
   },
   "dependencies": {


### PR DESCRIPTION
Fixes #161.

`package.json` advertised an `ollama-ai-provider-v2/internal` subpath that points at `internal/dist/index.*`, but the repository has no `internal` source entrypoint and the published tarball only contains the root `dist/index.*` files. Importing the advertised subpath therefore fails with `ERR_MODULE_NOT_FOUND`.

Since the README and source tree do not document or build a public internal entrypoint, this removes the stale `./internal` export and matching `files` allowlist entry instead of continuing to publish a broken subpath contract.

Verification:
- Reproduced before the change: build + pack + clean install, then `import('ollama-ai-provider-v2/internal')` failed because `internal/dist/index.mjs` was missing.
- `pnpm run build` succeeds.
- `pnpm test:node` passes: 3 files / 22 tests.
- Packed and installed into a clean consumer; verified `package.json` no longer advertises `./internal` and the root `import('ollama-ai-provider-v2')` still works.