### PR TITLE
Fix final text delta ordering in Ollama streams

### DIFF
--- a/src/responses/ollama-responses-language-model.test.ts
+++ b/src/responses/ollama-responses-language-model.test.ts
@@ -7,8 +7,10 @@ import {
   createTestConfig,
   prepareErrorResponse,
   prepareJsonResponse,
+  prepareStreamChunks,
   prepareStreamResponse,
 } from './test-helpers/ollama-test-helpers';
+import { convertReadableStreamToArray } from '../test-utils/test-server';
 
 describe('OllamaResponsesLanguageModel', () => {
   const testConfig = createTestConfig();
@@ -236,6 +238,92 @@ describe('OllamaResponsesLanguageModel', () => {
         });
 
         expect(result.stream).toBeDefined();
+      });
+
+      it('should emit final text delta before closing the text stream', async () => {
+        prepareStreamChunks(server, [
+          {
+            model: TEST_MODEL_ID,
+            created_at: '2024-01-01T00:00:00.000Z',
+            done: false,
+            message: {
+              role: 'assistant',
+              content: 'Hello',
+            },
+          },
+          {
+            model: TEST_MODEL_ID,
+            created_at: '2024-01-01T00:00:00.000Z',
+            done: true,
+            done_reason: 'stop',
+            message: {
+              role: 'assistant',
+              content: '!',
+            },
+            prompt_eval_count: 3,
+            eval_count: 2,
+          },
+        ]);
+
+        const result = await model.doStream({
+          prompt: TEST_PROMPT,
+        });
+        const parts = await convertReadableStreamToArray(result.stream);
+
+        expect(parts.map((part) => part.type)).toEqual([
+          'response-metadata',
+          'text-start',
+          'text-delta',
+          'text-delta',
+          'text-end',
+          'finish',
+        ]);
+        expect(parts.filter((part) => part.type === 'text-delta')).toEqual([
+          expect.objectContaining({ delta: 'Hello' }),
+          expect.objectContaining({ delta: '!' }),
+        ]);
+      });
+
+      it('should not emit empty text deltas for final done chunks', async () => {
+        prepareStreamChunks(server, [
+          {
+            model: TEST_MODEL_ID,
+            created_at: '2024-01-01T00:00:00.000Z',
+            done: false,
+            message: {
+              role: 'assistant',
+              content: 'Hello',
+            },
+          },
+          {
+            model: TEST_MODEL_ID,
+            created_at: '2024-01-01T00:00:00.000Z',
+            done: true,
+            done_reason: 'stop',
+            message: {
+              role: 'assistant',
+              content: '',
+            },
+            prompt_eval_count: 3,
+            eval_count: 1,
+          },
+        ]);
+
+        const result = await model.doStream({
+          prompt: TEST_PROMPT,
+        });
+        const parts = await convertReadableStreamToArray(result.stream);
+
+        expect(parts.filter((part) => part.type === 'text-delta')).toEqual([
+          expect.objectContaining({ delta: 'Hello' }),
+        ]);
+        expect(parts.map((part) => part.type)).toEqual([
+          'response-metadata',
+          'text-start',
+          'text-delta',
+          'text-end',
+          'finish',
+        ]);
       });
     });
   });

--- a/src/responses/ollama-responses-stream-processor.ts
+++ b/src/responses/ollama-responses-stream-processor.ts
@@ -127,13 +127,13 @@ export class OllamaStreamProcessor {
       });
     }
 
-    if (value.done) {
-      this.handleDoneChunk(value, controller);
-    }
-
     const delta = value?.message;
     if (delta) {
       this.processDelta(delta, controller);
+    }
+
+    if (value.done) {
+      this.handleDoneChunk(value, controller);
     }
   }
 
@@ -180,7 +180,7 @@ export class OllamaStreamProcessor {
     delta: OllamaResponse["message"],
     controller: TransformStreamDefaultController<LanguageModelV3StreamPart>,
   ) {
-    if (delta?.content != null) {
+    if (delta?.content) {
       if (!this.state.hasTextStarted) {
         controller.enqueue({ type: "text-start", id: this.state.textId });
         this.state.hasTextStarted = true;

--- a/src/responses/test-helpers/ollama-test-helpers.ts
+++ b/src/responses/test-helpers/ollama-test-helpers.ts
@@ -117,4 +117,14 @@ export const prepareStreamResponse = (
       eval_count: 5,
     },
   };
-}; 
+};
+
+export const prepareStreamChunks = (
+  server: ReturnType<typeof createMockServer>,
+  chunks: Array<Record<string, unknown>>,
+) => {
+  server.urls['http://127.0.0.1:11434/api/chat'].response = {
+    type: 'stream-chunks',
+    chunks: chunks.map((chunk) => `${JSON.stringify(chunk)}\n`),
+  };
+};


### PR DESCRIPTION
## Summary

- Emit a streamed chunk's text delta before closing the text stream on `done: true`
- Skip empty `message.content` chunks so Ollama's final done chunk does not produce an empty `text-delta`
- Add NDJSON stream regression coverage for node and edge test runs

## Why

Ollama streams can include a final `done: true` chunk with either final content or an empty content string. The stream processor handled `done` before processing the chunk delta, which could emit `text-end` before the final `text-delta`. Empty final content was also treated as a real text delta.

## Validation

- `pnpm test`

Additional checks attempted:

- `pnpm type-check` currently fails in `src/test-utils/test-server.ts` with `SetupServer` not assignable to `SetupServerApi` after install resolves `msw@2.14.6`.
- `pnpm lint` currently fails before linting because ESLint 10 cannot find an `eslint.config.*` file.
- `pnpm prettier-check` currently fails because `prettier` is not installed.
