### PR TITLE
Accept untagged file data so image parts stop throwing

### DIFF
--- a/src/adaptors/ollama-v4-helpers.ts
+++ b/src/adaptors/ollama-v4-helpers.ts
@@ -72,8 +72,21 @@ export function fileDataToDataUri(
 }
 
 export function extractOllamaFileData(
-  data: SharedV4FileData,
+  data: SharedV4FileData | URL | Uint8Array | string,
 ): URL | Uint8Array | string {
+  // Not every caller hands over the tagged SharedV4FileData shape: hosts running
+  // an older @ai-sdk/provider (OpenCode, for one) pass the payload directly, and
+  // the tagged switch below then falls through to its `never` branch and throws
+  // "Unsupported file data type: <the base64 itself>". Every downstream helper
+  // here already accepts the untagged union, so hand it straight back.
+  if (
+    typeof data === "string" ||
+    data instanceof URL ||
+    data instanceof Uint8Array
+  ) {
+    return data;
+  }
+
   switch (data.type) {
     case "data":
       return data.data;


### PR DESCRIPTION
### The bug

Any image attachment sent through a host running an older `@ai-sdk/provider` fails with:

```
Unsupported file data type: iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==
```

`extractOllamaFileData` switches on `data.type`, but such a host passes the payload **untagged** — a bare base64 string rather than `{ type: "data", data }`. The tagged switch falls through to its `never` branch and throws, interpolating the image data into the message.

I hit this running the provider under [OpenCode](https://opencode.ai), where it makes every image attachment fail. The request never reaches Ollama, so it isn't an Ollama-side limitation.

### The fix

Pass the untagged forms through before the tagged switch. Everything downstream — `fileDataToBase64String`, `fileDataToDataUri` — already accepts the `URL | Uint8Array | string` union, so this only widens the entry point.

### Verification

- With the patch, a PNG attachment round-trips through OpenCode 1.18.4 → Ollama 0.32.4 and the model describes the image correctly. Without it, the turn errors before any request goes out.
- Existing suite unchanged and green: **93 passing**.
- Also exercised multi-turn conversations, tool calls and subagent delegation against `gpt-oss` and `gemma4` to be sure nothing else moved.

### Note

I deliberately left thinking alone — `feautre/thinking-levels` already carries *"Change think from boolean to supporting strings"*, so that ground is yours. (For what it's worth, that change is worth landing: on Ollama 0.32.4 `gpt-oss` returned 37 thinking chars for `think:"low"` vs 414 for `think:"high"`, and a model without `.ThinkLevel` accepts a level rather than erroring.)

Happy to rebase or split this differently.